### PR TITLE
Update Zendo copy to use a macron as appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Carthage/*
 *.xcbkptlist
 *.xcbkptlist
 *.xcuserstate
+xcuserdata
 Charts/.github/ISSUE_TEMPLATE.md
 Charts/.github/PULL_REQUEST_TEMPLATE.md
 Charts/.swift-version

--- a/Zendo WatchKit App/Base.lproj/Interface.storyboard
+++ b/Zendo WatchKit App/Base.lproj/Interface.storyboard
@@ -254,7 +254,7 @@
                                         <imageView width="50" height="50" alignment="center" image="Lock" contentMode="scaleAspectFit" id="u0M-AT-oFY"/>
                                     </items>
                                 </group>
-                                <label alignment="center" text="Recording a meditation requires a monthly subscription. Go to Zendo app on the phone to subscribe. " textAlignment="center" numberOfLines="0" id="t4F-ed-mDq">
+                                <label alignment="center" text="Recording a meditation requires a monthly subscription. Go to Zendō app on the phone to subscribe. " textAlignment="center" numberOfLines="0" id="t4F-ed-mDq">
                                     <fontDescription key="font" name="Antenna-Medium" family="Antenna" pointSize="13"/>
                                 </label>
                                 <group width="1" height="40" alignment="left" radius="20" id="2XN-Qx-95s">

--- a/Zendo WatchKit App/Info.plist
+++ b/Zendo WatchKit App/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Zendo</string>
+	<string>Zendō</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Zendo/Controllers/Welcome/HealthKitViewController.swift
+++ b/Zendo/Controllers/Welcome/HealthKitViewController.swift
@@ -102,7 +102,7 @@ class HealthKitViewController: UIViewController {
             case 1: label.text = "sync failed"
             case 2: label.text =
             """
-            Zendo requires access to Health App.
+            Zendō requires access to Health App.
             
             1. Go to Health app.
             2. Tap on the Source Tab.

--- a/Zendo/Supporting Files/Info.plist
+++ b/Zendo/Supporting Files/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Zendō</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -57,9 +59,9 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Profile photo for groups</string>
 	<key>NSHealthShareUsageDescription</key>
-	<string>Show progress across Zendo sessions </string>
+	<string>Show progress across Zendō sessions </string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>Add Zendo data to Apple Health </string>
+	<string>Add Zendō data to Apple Health </string>
 	<key>NSMotionUsageDescription</key>
 	<string>Uses motion data to track posture</string>
 	<key>NSUserActivityTypes</key>


### PR DESCRIPTION
Should solve ticket https://app.asana.com/0/1113695757778657/1123312807951203/f

As noted in a conversation with Christina, the ō in Zendō looks a wee bit funny with the current font, but we're ok with that for now. 

I did my best to carefully look through the code to find the places where we have the string "Zendō" visible to the user. This appears to have fixed up all of them -- including the app icon's display name on the iOS device's home screen. 