### PR TITLE
Remove "create new session" button from Discover, Stats, and Activity

### DIFF
--- a/Zendo/Base.lproj/Main.storyboard
+++ b/Zendo/Base.lproj/Main.storyboard
@@ -235,13 +235,7 @@
                     </tableView>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <toolbarItems/>
-                    <navigationItem key="navigationItem" title="Activity" id="a61-4s-xIt">
-                        <barButtonItem key="rightBarButtonItem" title="New Session" image="watch" style="done" id="90w-8I-n8k">
-                            <connections>
-                                <action selector="onNewSession:" destination="OgR-X5-jbh" id="nGK-H9-nVS"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Activity" id="a61-4s-xIt"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="375" height="1000"/>
                 </tableViewController>
@@ -1164,13 +1158,7 @@ Use Apple Watch to record your meditation and view your Heart Rate Variability (
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="JLv-6G-LTB"/>
                     </view>
-                    <navigationItem key="navigationItem" title="full name" prompt="email" id="aBi-9f-bIj">
-                        <barButtonItem key="rightBarButtonItem" title="New Session" image="watch" style="done" id="0jC-fu-UI7">
-                            <connections>
-                                <action selector="onNewSession:" destination="y4I-bb-DEZ" id="prH-qE-wBl"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="full name" prompt="email" id="aBi-9f-bIj"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="414" height="1100"/>
                     <connections>
@@ -1194,7 +1182,6 @@ Use Apple Watch to record your meditation and view your Heart Rate Variability (
         <image name="overview" width="24" height="24"/>
         <image name="share" width="24" height="24"/>
         <image name="time" width="35" height="40"/>
-        <image name="watch" width="13" height="23"/>
         <image name="welcome" width="248" height="319"/>
     </resources>
 </document>

--- a/Zendo/Controllers/Discover/Discover.storyboard
+++ b/Zendo/Controllers/Discover/Discover.storyboard
@@ -163,13 +163,7 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Ar3-ZE-Yqr"/>
                     </view>
-                    <navigationItem key="navigationItem" title="Discover" id="1WB-04-bbZ">
-                        <barButtonItem key="rightBarButtonItem" title="New Session" image="watch" style="done" id="dkd-Fl-9rH">
-                            <connections>
-                                <action selector="onNewSession:" destination="FV6-Tz-yMd" id="1Vb-gD-nrX"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="Discover" id="1WB-04-bbZ"/>
                     <connections>
                         <outlet property="tableView" destination="xhR-1H-DLz" id="z8Q-6G-WQH"/>
                     </connections>
@@ -595,6 +589,5 @@
         <image name="checkmark" width="16" height="11"/>
         <image name="discover" width="20" height="20"/>
         <image name="overlay_green" width="290" height="89"/>
-        <image name="watch" width="13" height="23"/>
     </resources>
 </document>


### PR DESCRIPTION
Does what it says on the tin -- removes the bar button kicking off a new watch session from the Discover, Stats, and Activity flows.

It's worth noting that the Activity page looks a little funky now, with an arrow pointing into the abyss.